### PR TITLE
cancel roder

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,4 +47,5 @@ Rails.application.routes.draw do
   delete 'POS/inventory', to: 'inventory#destroy'
   delete 'POS/menu', to: 'menu#destroy'
   delete 'POS/orders', to: 'orders#destroy'
+  delete 'client/order', to: 'orders#cancel'
 end


### PR DESCRIPTION
Quickly added a cancel order mechanic at the client/order endpoint (feel free to change it if you don't like it). you just need to send in an existing username with an order and that person's order will be removed and all ingredients will be restocked. This is different from a completed order which doesn't restock the ingredients.